### PR TITLE
Provides the ability to set the full array of port_overrides in one call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+# JetBrains Idea
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,18 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Lock files
+package-lock.json
+yarn.lock
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Idea
+.idea

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ node-red-contrib-unifi is a Node-RED module that allows to query/control [UniFi 
 * deleteFirewallGroup: Delete firewall group { command: "deleteFirewallGroup", group_id: "group id" }
 * forceProvision : Force provision { command: "forceProvision", mac: "device MAC address" }
 * !! Will remove manual set Profiles !! setPortProfile : Set Port Profile { command: "setPortProfile", device_id: "24 char device id", profile_id: "Profile id", port_id: "Port number" }
+* setPortProfiles: Set overrides for multiple ports of a device { command: "setPortProfiles", device_id: "24 char device id", port_overrides: [ {"port_idx": 1, "portconf_id": "id of the port profile", "name": "friendly name of the port", "poe_mode": "off|auto" }, ... ] }
 * setLocate : Enable flash device LED (or other indication based on device) { command: "setLocate", mac: "device MAC address" }
 * unsetLocate : Disable flash device LED (or other indication based on device) { command: "unsetLocate", mac: "device MAC address" }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-unifi",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Node for Node-RED to connect to a UniFi Controller ",
   "main": "unifi.js",
   "dependencies": {

--- a/unifi-helper.js
+++ b/unifi-helper.js
@@ -1455,6 +1455,18 @@ var Controller = function (hostname, port, unifios) {
         _self._request('/api/s/<SITE>/rest/device/' + device_id.trim(), json, sites, cb, 'PUT');
     };
 
+    /**
+     * Set switch port profiles for multiple ports on the same device
+     * ------------------------------
+     *
+     * required parameter <device_id>  = 24 char string; value of _id for the device which can be obtained from the device list
+     * required parameter <port_overrides> = array of port override config objects
+     */
+    _self.setPortProfiles = function (sites, device_id, port_overrides, cb) {
+        var json = { port_overrides: port_overrides };
+        _self._request('/api/s/<SITE>/rest/device/' + device_id.trim(), json, sites, cb, 'PUT');
+    }
+
     /** PRIVATE FUNCTIONS **/
 
     /**

--- a/unifi.html
+++ b/unifi.html
@@ -109,6 +109,7 @@
             <li><code>deleteFirewallGroup</code> : Delete firewall group { command: "deleteFirewallGroup", group_id: "group id" }</li>
             <li><code>forceProvision</code> : Force provision { command: "forceProvision", mac: "device MAC address" }</li>
             <li><code>setPortProfile</code> : !! Will remove manual set Profiles !! Set Port Profile { command: "setPortProfile", device_id: "24 char device id", profile_id: "Profile id", port_id: "Port number" }</li>
+            <li><code>setPortProfiles</code> : setPortProfiles: Set overrides for multiple ports of a device { command: "setPortProfiles", device_id: "24 char device id", port_overrides: [ {"port_idx": 1, "portconf_id": "id of the port profile", "name": "friendly name of the port", "poe_mode": "off|auto" }, ... ] }</li>
             <li><code>setLocate</code> : Enable flash device LED (or other indication based on device) { command: "setLocate", mac: "device MAC address" }</li>
             <li><code>unsetLocate</code> : Disable flash device LED (or other indication based on device) { command: "unsetLocate", mac: "device MAC address" }</li>
 	<p>Returns all data in JSON parsable strings/objects</p>

--- a/unifi.js
+++ b/unifi.js
@@ -145,6 +145,9 @@ module.exports = function (RED) {
                     case 'setportprofile':
                         controller.setPortProfile(site, msg.payload.device_id, msg.payload.profile_id, msg.payload.port_id, handleDataCallback);
                         break;
+                    case 'setportprofiles':
+                        controller.setPortProfiles(site, msg.payload.device_id, msg.payload.port_overrides, handleDataCallback);
+                        break;
                     case 'setlocate':
                         controller.setLocateAccessPoint(site, msg.payload.mac, true, handleDataCallback);
                         break;


### PR DESCRIPTION
Fixes #34 

* Added `_self.setPortProfiles` to `unifi-helper.js`
* Added case for `setportprofiles` to `unifi.js`
* Provided some documentation for the command
* Added `.npmignore` for easier publishing / packaging
* Added IntelliJ IDEA settings to `.gitignore`
* Increased version number