### PR TITLE
 Toggle PoE / Firewall Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ node-red-contrib-unifi is a Node-RED module that allows to query/control [UniFi 
 * addFirewallGroup: Add firewall group { command: "addFirewallGroup", group_name: "group-name", group_type: "address-group|ipv6-address-group|port-group", group_members: ["CIDRs", "IPs"] }
 * editFirewallGroup: Edit firewall group { command: "editFirewallGroup", group_id: "group id", group_name: "group-name", group_type: "address-group|ipv6-address-group|port-group", group_members: ["CIDRs", "IPs"] }
 * deleteFirewallGroup: Delete firewall group { command: "deleteFirewallGroup", group_id: "group id" }
+*getFirewallRules: Get a list of firewall rules { command: "getFirewallRules" }
+*getFirewallRule: Get a firewall rule { command: "getFirewallRule, rule_id: "id" }
+*getFirewallRuleByName: Get a firewall rule by its name{ command: "getFirewallRuleByName, rule_name: "name" }
+*enableFirewallRule: Enable a firewall rule { command: "enableFirewallRule", rule_id: "id" }
+*disableFirewallRule: Disable a firewall rule { command: "disableFirewallRule", rule_id: "id" }
+*getPoePortState: Get the PoE state of port x { command: "getPoePortState", device_id: "id", port: "port number" }
+*enablePoePort: Enable POE on port x { command: "enablePoePort", device_id: "id", port: "port number", poe_mode: "off|auto|pasv24" }
+*disablePoePort: Disable POE on port x { command: "disablePoePort", device_id: "id", port: "port number"  }
 * forceProvision : Force provision { command: "forceProvision", mac: "device MAC address" }
 * setPortProfiles: Set overrides for multiple ports of a device { command: "setPortProfiles", device_id: "24 char device id", port_overrides: [ {"port_idx": 1, "portconf_id": "id of the port profile", "name": "friendly name of the port", "poe_mode": "off|auto" }, ... ] }
 * setLocate : Enable flash device LED (or other indication based on device) { command: "setLocate", mac: "device MAC address" }

--- a/unifi.html
+++ b/unifi.html
@@ -113,6 +113,14 @@
             <li><code>addFirewallGroup</code> : Add firewall group { command: "addFirewallGroup", group_name: "group-name", group_type: "address-group|ipv6-address-group|port-group", group_members: ["CIDRs", "IPs"] }</li>
             <li><code>editFirewallGroup</code> : Edit firewall group { command: "editFirewallGroup", group_id: "group id", group_name: "group-name", group_type: "address-group|ipv6-address-group|port-group", group_members: ["CIDRs", "IPs"] }</li>
             <li><code>deleteFirewallGroup</code> : Delete firewall group { command: "deleteFirewallGroup", group_id: "group id" }</li>
+            <li><code>getFirewallRules</code> : Get a list of firewall rules { command: "getFirewallRules" }</li>
+            <li><code>getFirewallRule</code> : Get a firewall rule { command: "getFirewallRule, rule_id: "id" }</li>
+            <li><code>getFirewallRuleByName</code> : Get a firewall rule by its name{ command: "getFirewallRuleByName, rule_name: "name" }</li>
+            <li><code>enableFirewallRule</code> : Enable a firewall rule { command: "enableFirewallRule", rule_id: "id" }</li>
+            <li><code>disableFirewallRule</code> : Disable a firewall rule { command: "disableFirewallRule", rule_id: "id" }</li>
+            <li><code>getPoePortState</code> : Get the PoE state of port x { command: "getPoePortState", device_id: "id", port: "port number" }</li>
+            <li><code>enablePoePort</code> : Enable POE on port x { command: "enablePoePort", device_id: "id", port: "port number", poe_mode: "off|auto|pasv24" }</li>
+            <li><code>disablePoePort</code> : Disable POE on port x { command: "disablePoePort", device_id: "id", port: "port number" }</li>
             <li><code>forceProvision</code> : Force provision { command: "forceProvision", mac: "device MAC address" }</li>
             <li><code>setPortProfiles</code> : setPortProfiles: Set overrides for multiple ports of a device { command: "setPortProfiles", device_id: "24 char device id", port_overrides: [ {"port_idx": 1, "portconf_id": "id of the port profile", "name": "friendly name of the port", "poe_mode": "off|auto" }, ... ] }</li>
             <li><code>setLocate</code> : Enable flash device LED (or other indication based on device) { command: "setLocate", mac: "device MAC address" }</li>

--- a/unifi.js
+++ b/unifi.js
@@ -153,6 +153,30 @@ module.exports = function (RED) {
                     case 'deletefirewallgroup':
                         controller.deleteFirewallGroup(site, msg.payload.group_id, handleDataCallback);
                         break;
+                    case 'getfirewallrules':
+                        controller.getFirewallRules(site, handleDataCallback);
+                        break;
+                    case 'getfirewallrule':
+                        controller.getFirewallRule(site, msg.payload.rule_id, handleDataCallback);
+                        break;
+                    case 'getfirewallrulebyname':
+                        controller.getFirewallRuleByName(site, msg.payload.rule_name, handleDataCallback);
+                        break;
+                    case 'enablefirewallrule':
+                        controller.disableFirewallRule(site, msg.payload.rule_id, true, handleDataCallback);
+                        break;
+                    case 'disablefirewallrule':
+                        controller.disableFirewallRule(site, msg.payload.rule_id, false, handleDataCallback);
+                        break;
+                    case 'getpoeportstate':
+                        controller.getPoePortState(site, msg.payload.device_id, msg.payload.port, handleDataCallback);
+                        break;
+                    case 'enablepoeport':
+                        controller.disablePoePort(site, msg.payload.device_id, msg.payload.port, msg.payload.poe_mode, handleDataCallback);
+                        break;
+                    case 'disablepoeport':
+                        controller.disablePoePort(site, msg.payload.device_id, msg.payload.port, 'off', handleDataCallback);
+                        break;
                     case 'forceprovision':
                         controller.forceProvision(site, msg.payload.mac, handleDataCallback);
                         break;


### PR DESCRIPTION
Hi,

this PR will add the commands for turn PoE (issue 67) on and off and for enable and disable firewall rules (issue 45).
It was tested on a Unifi Controller v. 7.0.25. 

Greetings, JE

added
- getFirewallRules
- getFirewallRule
- getFirewallRuleByName
- enableFirewallRule
- disableFirewallRule
- getPoePortState
- enablePoePort
- disablePoePort