### PR TITLE
Missing case for setWLanSettings

### DIFF
--- a/unifi-helper.js
+++ b/unifi-helper.js
@@ -1154,7 +1154,7 @@ var Controller = function (hostname, port, unifios, ssl, debug) {
      * optional parameter <name>
      *
      */
-    _self.setWLanSettings = function (sites, wlan_id, cb, x_passphrase, name) {
+    _self.setWLanSettings = function (sites, wlan_id, x_passphrase, name, cb) {
         var json = {};
 
         if (typeof (x_passphrase) !== 'undefined')

--- a/unifi.js
+++ b/unifi.js
@@ -233,6 +233,9 @@ module.exports = function (RED) {
                     case 'setwlanpassword':
                         controller.setWLanPassword(site, msg.payload.wlan_id, msg.payload.x_passphrase, handleDataCallback);
                         break;
+                    case 'setwlansettings':
+                        controller.setWLanSettings(site, msg.payload.wlan_id, msg.payload.x_passphrase, msg.payload.name, handleDataCallback);
+                        break;
                     case 'getvouchers':
                         controller.getVouchers(site, handleDataCallback)
                         break;


### PR DESCRIPTION
Could not use the function due to missing case. 

Useful for changing the SSID name of an existing WLAN. Going to use it for my own guest wifi at home as it can be changed to a random SSID at random intervals when there are no guests logged in for n-days for example. 

My very first pull request so I hope I didn't mess it up :) 
Thanks for your work
/Another one from SWE